### PR TITLE
Add :invitation_redirect_url config for Usher Web

### DIFF
--- a/dev.exs
+++ b/dev.exs
@@ -112,7 +112,7 @@ Task.async(fn ->
   ]
 
   # Reset the DB
-  :ok = Ecto.Adapters.Postgres.storage_down(Usher.Dev.Repo.config())
+  Ecto.Adapters.Postgres.storage_down(Usher.Dev.Repo.config())
   :ok = Ecto.Adapters.Postgres.storage_up(Usher.Dev.Repo.config())
 
   {:ok, _pid} = Supervisor.start_link(children, strategy: :one_for_one)

--- a/guides/configuration.md
+++ b/guides/configuration.md
@@ -1,0 +1,37 @@
+# Configuration
+
+This guide covers configuration options for Usher Web and the underlying Usher library.
+
+## Usher Web Configuration
+
+Usher Web provides its own configuration options that should be added to your `config/config.exs` file:
+
+```elixir
+config :usher_web,
+  invitation_redirect_url: "https://myapp.com"
+```
+
+### Configuration Options
+
+#### `:invitation_redirect_url`
+
+The URL where users will be redirected when they click invitation links.
+
+- **Type**: `String.t()`
+- **Default**: `"http://localhost:4000"`
+- **Required**: No
+
+**Example:**
+
+```elixir
+config :usher_web,
+  invitation_redirect_url: "https://myapp.com"
+```
+
+When configured, invitation links will redirect users to this URL. For example, if you set it to `"https://myapp.com"`, the generated invitation links will look like `https://myapp.com/invitations/abcdef`.
+
+## Usher Library Configuration
+
+Usher Web depends on the [Usher library](https://hexdocs.pm/usher) for core invitation management functionality. You need to configure Usher separately in your `config/config.exs` file.
+
+For more detailed information about Usher library configuration options, see the [Usher Configuration guide](https://hexdocs.pm/usher/configuration.html).

--- a/guides/getting-started.md
+++ b/guides/getting-started.md
@@ -12,7 +12,9 @@ Before you begin, make sure you have:
 
 ## Configuration
 
-Usher Web itself doesn't require any configuration. However, you do need to configure the underlying [Usher library](https://hexdocs.pm/usher) that Usher Web depends on.
+### Usher Library Configuration
+
+You need to configure the underlying [Usher library](https://hexdocs.pm/usher) that Usher Web depends on.
 
 Configure Usher in your `config/config.exs` file.
 
@@ -31,6 +33,19 @@ config :usher,
 ```
 
 You can find details about configuration options in [Usher's Configuration guide](https://hexdocs.pm/usher/configuration.html).
+
+### Usher Web Configuration
+
+Usher Web needs its own configuration:
+
+```elixir
+config :usher_web,
+  invitation_redirect_url: "https://myapp.com"
+```
+
+Currently, you can only configure the `:invitation_redirect_url`, which specifies where users will be redirected when they click invitation links. Defaults to `"http://localhost:4000"` if not provided. For example, if you set it to `"https://myapp.com"`, the generated invitation links will look like `https://myapp.com/invitations/abcdef`.
+
+See the [Configuration guide](configuration.md) for more details.
 
 ## Routing to Usher Web Views
 

--- a/lib/usher/web/config.ex
+++ b/lib/usher/web/config.ex
@@ -1,0 +1,15 @@
+defmodule Usher.Web.Config do
+  @moduledoc """
+  Provides functions to retrieve configuration values for the Usher Web application.
+  """
+
+  @doc """
+  Returns the URL where users will be redirected when they click invitation links.
+
+  Defaults to "http://localhost:4000" if not configured.
+  """
+  @spec invitation_redirect_url() :: String.t()
+  def invitation_redirect_url do
+    Application.get_env(:usher_web, :invitation_redirect_url, "http://localhost:4000")
+  end
+end

--- a/lib/usher/web/live/invitations_list.ex
+++ b/lib/usher/web/live/invitations_list.ex
@@ -5,6 +5,7 @@ defmodule Usher.Web.Live.InvitationsList do
 
   alias Usher.Invitation
   alias Usher.Web.Components.InvitationFormComponent
+  alias Usher.Web.Config
 
   import Usher.Web.Helpers.DateTimeHelpers
 
@@ -60,7 +61,7 @@ defmodule Usher.Web.Live.InvitationsList do
                 href={token_link(invitation)}
                 target="_blank"
               >
-                {token_link_display_value(token_link(invitation))}
+                {token_link(invitation) |> token_link_display_value()}
               </.link>
               <.button
                 id={"copy-invitation-token-link-#{id}"}
@@ -269,8 +270,9 @@ defmodule Usher.Web.Live.InvitationsList do
   end
 
   defp token_link(invitation) do
-    # signup_url = app_url("signup")
-    Usher.invitation_url(invitation.token, "http://localhost:4000")
+    invitation_redirect_url = Config.invitation_redirect_url()
+
+    Usher.invitation_url(invitation.token, invitation_redirect_url)
   end
 
   defp token_link_display_value(link) do

--- a/mix.exs
+++ b/mix.exs
@@ -132,6 +132,7 @@ defmodule Usher.Web.MixProject do
       "guides/overview.md",
       "guides/installation.md",
       "guides/getting-started.md",
+      "guides/configuration.md",
       "guides/contributing.md"
     ]
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -47,5 +47,6 @@ _ = Usher.Web.TestRepo.__adapter__().storage_up(Usher.Web.TestRepo.config())
 Ecto.Adapters.SQL.Sandbox.mode(Usher.Web.TestRepo, :manual)
 
 Mimic.copy(DateTime)
+Mimic.copy(Application)
 
 ExUnit.start(assert_receive_timeout: 500, refute_receive_timeout: 50, exclude: [:skip])

--- a/test/usher/web/config_test.exs
+++ b/test/usher/web/config_test.exs
@@ -1,0 +1,29 @@
+defmodule Usher.Web.ConfigTest do
+  use ExUnit.Case, async: true
+
+  import Mimic
+
+  alias Usher.Web.Config
+
+  setup :verify_on_exit!
+
+  describe "invitation_redirect_url/0" do
+    test "returns configured invitation redirect URL" do
+      Application
+      |> expect(:get_env, fn :usher_web, :invitation_redirect_url, _default ->
+        "https://example.com"
+      end)
+
+      assert Config.invitation_redirect_url() == "https://example.com"
+    end
+
+    test "returns default when not configured" do
+      Application
+      |> expect(:get_env, fn :usher_web, :invitation_redirect_url, default ->
+        default
+      end)
+
+      assert Config.invitation_redirect_url() == "http://localhost:4000"
+    end
+  end
+end


### PR DESCRIPTION
Required for setting the URL for the invitation token redirect.